### PR TITLE
Update for uuid.NewV4() breaking changes

### DIFF
--- a/offers.go
+++ b/offers.go
@@ -89,7 +89,7 @@ func (m *RebindManager) MakeOffer(ctx context.Context, req WebSocketHostRequest)
 	// Loop each method and configure
 	var offers []RebindOffer
 	for _, method := range methods {
-		id := uuid.NewV4()
+		id, _ := uuid.NewV4()
 		offers = append(offers, RebindOffer{
 			ID:  id,
 			URL: fmt.Sprintf("http://%s.%s:%s/.well-known/rebind/v1.frame", id, m.base, req.Host.Port),

--- a/socket.go
+++ b/socket.go
@@ -90,7 +90,7 @@ func (m *RebindManager) WebSocketHandler(w http.ResponseWriter, req *http.Reques
 		return
 	}
 	// Each socket has an ID
-	id := uuid.NewV4()
+	id, _ := uuid.NewV4()
 	log.Infof(`New socket connection "%s"`, id)
 	// Create a cancel-able child context
 	ctx, triggerClose := context.WithCancel(req.Context())


### PR DESCRIPTION
`uuid` recently pushed a breaking change to their `uuid.NewV4()` API: https://github.com/satori/go.uuid/issues/66. I've made small updates that account for these changes and allow Jaqen to be compiled.